### PR TITLE
Note on preserving context when refactoring for-loop

### DIFF
--- a/patterns/javascript/replace-for-with-foreach.md
+++ b/patterns/javascript/replace-for-with-foreach.md
@@ -19,6 +19,20 @@ Use the ECMAScript 5 `forEach` method instead.
 });
 ```
 
+If you depend on the context of `this` then pass in context as the second parameter, or `bind` context to the function
+
+```javascript
+{
+  honorific: 'Ms.',
+  surnames: ['Jones', 'Smith'],
+  logNames: function(){
+    this.surnames.forEach(function(name){
+        console.log(this.honorific+' '+name); // 'Ms. Jones', 'Ms. Smith'
+    }, this) // forEach runs in global context by default, 'undefined Jones', 'undefined Smith'; or is undefined in strict mode, causing an error
+  }
+}
+```
+
 # More Information
 
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for


### PR DESCRIPTION
Moving from a for-loop to `forEach` can have side effects when the logic depends on context, so add an example
